### PR TITLE
Feature/multiple creatures per food

### DIFF
--- a/include/creature.h
+++ b/include/creature.h
@@ -26,7 +26,7 @@ private:
     void update_location();
 
 public:
-    Creature(uint16_t init_id, float init_energy, Food* init_food);
+    Creature(uint16_t init_id, float init_energy, Food* init_food, point init_location);
     ~Creature() = default;
 
     Creature& operator=(const Creature& other) {

--- a/include/creature.h
+++ b/include/creature.h
@@ -14,14 +14,14 @@ private:
     const uint16_t max_visable_distace_ = 10;
     const uint16_t speed_ = 4;
 
-    point current_location_;
-    point next_location_;
-
     uint16_t id_;
     float energy_;
+    point current_location_;
+    point next_location_;
     std::shared_ptr<Food> food_;
     std::optional<point> closest_visable_food_;
     std::optional<point> last_food_eaten_;
+    uint16_t food_request_id_;
 
     void update_location();
 
@@ -37,6 +37,7 @@ public:
 
     std::optional<point> last_food_eaten();
     void perform_day_actions();
+    void update_energy();
     
     uint16_t id()         { return id_; }
     float energy()        { return energy_; }

--- a/include/creature.h
+++ b/include/creature.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <vector>
 
+#include "food.h"
 #include "types.h"
 
 namespace evo_sim {
@@ -17,16 +19,14 @@ private:
 
     uint16_t id_;
     float energy_;
-    std::vector<point> visable_food_;
-    point closest_visable_food_;
+    std::shared_ptr<Food> food_;
+    std::optional<point> closest_visable_food_;
     std::optional<point> last_food_eaten_;
 
-    void update_visable_food(std::vector<point> all_food);
     void update_location();
-    float distance(point a, point b);
 
 public:
-    Creature(uint16_t init_id, float init_energy, std::vector<point> init_food);
+    Creature(uint16_t init_id, float init_energy, Food* init_food);
     ~Creature() = default;
 
     Creature& operator=(const Creature& other) {
@@ -36,7 +36,7 @@ public:
     }
 
     std::optional<point> last_food_eaten();
-    void perform_day_actions(std::vector<point> all_food);
+    void perform_day_actions();
     
     uint16_t id()         { return id_; }
     float energy()        { return energy_; }

--- a/include/evo_math.h
+++ b/include/evo_math.h
@@ -5,5 +5,9 @@
 #include "types.h"
 
 namespace evo_sim {
+    // Returns the distance between two points
     float distance(point a, point b);
+
+    // Returns the summation of an integer and all integrs smaller than it
+    uint32_t triangular_number(uint16_t n);
 };

--- a/include/evo_math.h
+++ b/include/evo_math.h
@@ -1,5 +1,3 @@
-#ifndef __EVO_MATH_H__
-#define __EVO_MATH_H__
 #pragma once
 
 #include <math.h>
@@ -7,11 +5,5 @@
 #include "types.h"
 
 namespace evo_sim {
-    float distance(point a, point b) {
-        uint32_t x = pow(a.first - b.first , 2);
-        uint32_t y = pow(a.second - b.second, 2);
-        return sqrt(x + y);
-    }
+    float distance(point a, point b);
 };
-
-#endif

--- a/include/evo_math.h
+++ b/include/evo_math.h
@@ -1,0 +1,17 @@
+#ifndef __EVO_MATH_H__
+#define __EVO_MATH_H__
+#pragma once
+
+#include <math.h>
+
+#include "types.h"
+
+namespace evo_sim {
+    float distance(point a, point b) {
+        uint32_t x = pow(a.first - b.first , 2);
+        uint32_t y = pow(a.second - b.second, 2);
+        return sqrt(x + y);
+    }
+};
+
+#endif

--- a/include/food.h
+++ b/include/food.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <optional>
 
 #include "types.h"
 
@@ -26,6 +27,9 @@ public:
     // received from request and returns the amount of energy received from eating the food. 
     float get_energy(point location, uint16_t id);
 
+    std::optional<point> closest_food(point ref, uint16_t max_visable_disatnce);
+    void remove_food(point ref);
+    bool is_food(point ref);
 }; // End class Food
 
 }; // End namespace evo_sim

--- a/include/food.h
+++ b/include/food.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <optional>
+#include <queue>
 
 #include "types.h"
 
@@ -14,6 +15,8 @@ private:
     // Key is the food's location in the world.  Value is the number of creatures trying to eat the food.
     std::map<point, uint16_t> food_pieces_;
 
+    std::queue<point> food_eaten_;
+
 public:
     Food();
     ~Food() = default;
@@ -24,11 +27,12 @@ public:
     uint16_t request(point location);
 
     // Called after all creatures have performed their move. Passed point food is received from andthe ID
-    // received from request and returns the amount of energy received from eating the food. 
+    // received from request and returns the amount of energy received from eating the food.  The value
+    // of food received decreases for each subsequent request.
     float get_energy(point location, uint16_t id);
 
     std::optional<point> closest_food(point ref, uint16_t max_visable_disatnce);
-    void remove_food(point ref);
+    void remove_eaten_food();
     bool is_food(point ref);
 }; // End class Food
 

--- a/include/food.h
+++ b/include/food.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <map>
+
+#include "types.h"
+
+namespace evo_sim {
+
+class Food {
+private:
+    static constexpr float energy_ = 2.0;
+
+    // Key is the food's location in the world.  Value is the number of creatures trying to eat the food.
+    std::map<point, uint16_t> food_pieces_;
+
+public:
+    Food();
+    ~Food() = default;
+
+    // Called when a creature reaches location.  Logs that the creature is trying to eat the food.
+    // Returns an ID to be used with get to receive the energy from eating the food.
+    uint16_t request(point location);
+
+    // Called after all creatures have performed their move. Passed the ID received from request and returns
+    // the amount of energy received from eating the food. 
+    float get_energy(uint16_t);
+
+}; // End class Food
+
+}; // End namespace evo_sim

--- a/include/food.h
+++ b/include/food.h
@@ -19,11 +19,12 @@ public:
 
     // Called when a creature reaches location.  Logs that the creature is trying to eat the food.
     // Returns an ID to be used with get to receive the energy from eating the food.
+    // An ID of 0 is returned for invalid requests.
     uint16_t request(point location);
 
-    // Called after all creatures have performed their move. Passed the ID received from request and returns
-    // the amount of energy received from eating the food. 
-    float get_energy(uint16_t);
+    // Called after all creatures have performed their move. Passed point food is received from andthe ID
+    // received from request and returns the amount of energy received from eating the food. 
+    float get_energy(point location, uint16_t id);
 
 }; // End class Food
 

--- a/include/world.h
+++ b/include/world.h
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "creature.h"
+#include "food.h"
 #include "types.h"
 
 namespace evo_sim {
@@ -13,7 +14,7 @@ private:
     static constexpr uint16_t height_ = 20;
 
     std::vector<Creature> creatures_;
-    std::vector<point> food_locations_;
+    Food food_;
 
 public:
 
@@ -22,10 +23,10 @@ public:
 
     void update_state();
     
-    std::vector<Creature> creatures()   { return creatures_; }
-    std::vector<point> food_locations() { return food_locations_; }
-    uint16_t width()                    { return width_; }
-    uint16_t height()                   { return height_; }
+    std::vector<Creature> creatures() { return creatures_; }
+    Food* food()                      { return &food_; }
+    uint16_t width()                  { return width_; }
+    uint16_t height()                 { return height_; }
 
 }; // End class World
 

--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 int main() {
     evo_sim::World world{};
     evo_sim::Logger logger(&world);
-    
+
     logger.log_world_state();
     while (world.creatures().size() > 0) {
         world.update_state();

--- a/src/Food.cpp
+++ b/src/Food.cpp
@@ -1,4 +1,8 @@
+#include <cfloat>
+#include <math.h>
+
 #include "food.h"
+#include "evo_math.h"
 
 evo_sim::Food::Food() {
     food_pieces_.emplace(std::pair{1, 1}, 0);
@@ -14,4 +18,33 @@ uint16_t evo_sim::Food::request(point location) {
 
 float evo_sim::Food::get_energy(point location, uint16_t id) {
     return energy_;
+}
+
+std::optional<evo_sim::point> evo_sim::Food::closest_food(point ref, uint16_t max_visable_disatnce) {
+    float distance_to_closest_food = FLT_MAX;
+    std::optional<point> closest_food = std::nullopt;
+
+    for (const std::pair<point, uint16_t> food : food_pieces_) {
+        // Filter food outside visable range
+        if (abs(food.first.first - ref.first) > max_visable_disatnce) { continue; }
+        if (abs(food.first.second - ref.second) > max_visable_disatnce) { continue; }
+
+        // Get distance to food
+        float distance_to_food = distance(food.first, ref);
+
+        // Track closest food
+        if (distance_to_food > distance_to_closest_food) { continue; }
+        distance_to_closest_food = distance_to_food;
+        closest_food = food.first;
+    }
+
+    return closest_food;
+}
+
+void evo_sim::Food::remove_food(point ref) {
+    food_pieces_.erase(ref);
+}
+
+bool evo_sim::Food::is_food(point ref) {
+    return !food_pieces_.count(ref) == 0;
 }

--- a/src/Food.cpp
+++ b/src/Food.cpp
@@ -1,0 +1,17 @@
+#include "food.h"
+
+evo_sim::Food::Food() {
+    food_pieces_.emplace(std::pair{1, 1}, 0);
+    food_pieces_.emplace(std::pair{2, 2}, 0);
+    food_pieces_.emplace(std::pair{2, 5}, 0);
+    food_pieces_.emplace(std::pair{2, 12}, 0);
+}
+
+uint16_t evo_sim::Food::request(point location) {
+    if (food_pieces_.count(location) == 0) { return 0; }
+    return ++food_pieces_[location];
+}
+
+float evo_sim::Food::get_energy(point location, uint16_t id) {
+    return energy_;
+}

--- a/src/Food.cpp
+++ b/src/Food.cpp
@@ -17,7 +17,15 @@ uint16_t evo_sim::Food::request(point location) {
 }
 
 float evo_sim::Food::get_energy(point location, uint16_t id) {
-    return energy_;
+    if (food_pieces_.count(location) == 0) { return 0.0; }
+
+    food_eaten_.push(location);
+
+    if (food_pieces_[location] == 1) { return energy_; }
+
+    uint32_t portions = triangular_number(food_pieces_[location]);
+    float portion_size = energy_ / portions;
+    return portion_size * (id - (id - 1));
 }
 
 std::optional<evo_sim::point> evo_sim::Food::closest_food(point ref, uint16_t max_visable_disatnce) {
@@ -41,8 +49,16 @@ std::optional<evo_sim::point> evo_sim::Food::closest_food(point ref, uint16_t ma
     return closest_food;
 }
 
-void evo_sim::Food::remove_food(point ref) {
-    food_pieces_.erase(ref);
+void evo_sim::Food::remove_eaten_food() {
+    while (!food_eaten_.empty()) {
+        point food = food_eaten_.front();
+
+        if (food_pieces_.count(food) > 0) {
+            food_pieces_.erase(food);
+        }
+
+        food_eaten_.pop();
+    }
 }
 
 bool evo_sim::Food::is_food(point ref) {

--- a/src/Food.cpp
+++ b/src/Food.cpp
@@ -5,10 +5,10 @@
 #include "evo_math.h"
 
 evo_sim::Food::Food() {
-    food_pieces_.emplace(std::pair{1, 1}, 0);
-    food_pieces_.emplace(std::pair{2, 2}, 0);
-    food_pieces_.emplace(std::pair{2, 5}, 0);
-    food_pieces_.emplace(std::pair{2, 12}, 0);
+    food_pieces_.emplace(std::pair{3, 1}, 0);
+    // food_pieces_.emplace(std::pair{2, 2}, 0);
+    // food_pieces_.emplace(std::pair{2, 5}, 0);
+    // food_pieces_.emplace(std::pair{2, 12}, 0);
 }
 
 uint16_t evo_sim::Food::request(point location) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -7,17 +7,22 @@
 evo_sim::Creature::Creature(uint16_t init_id, float init_energy, Food* init_food)
     : id_ {init_id}
     , energy_ {init_energy}
-    , food_ {init_food}
     , current_location_ {0, 0}
     , next_location_ {0, 0}
-    , last_food_eaten_ {std::nullopt}
+    , food_ {init_food}
     , closest_visable_food_ {food_->closest_food(current_location_, max_visable_distace_)}
+    , last_food_eaten_ {std::nullopt}
+    , food_request_id_ {0}
 { }
 
 void evo_sim::Creature::perform_day_actions() {   
     energy_ -= 1.5; // TODO - make this a function of max_visable_distance_
     closest_visable_food_ = food_->closest_food(current_location_, max_visable_distace_);
     update_location();
+}
+
+void evo_sim::Creature::update_energy() {
+    energy_ += food_->get_energy(current_location_, food_request_id_);
 }
 
 void evo_sim::Creature::update_location() {
@@ -33,6 +38,7 @@ void evo_sim::Creature::update_location() {
         next_location_.second = current_location_.second + (y_dif * distance_ratio);
     } else {
         next_location_ = closest_visable_food_.value();
+        food_request_id_ = food_->request(next_location_);
     }
 
     // Energy cost for moving

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -4,10 +4,10 @@
 #include "evo_math.h"
 #include "creature.h"
 
-evo_sim::Creature::Creature(uint16_t init_id, float init_energy, Food* init_food)
+evo_sim::Creature::Creature(uint16_t init_id, float init_energy, Food* init_food, point init_location)
     : id_ {init_id}
     , energy_ {init_energy}
-    , current_location_ {0, 0}
+    , current_location_ {init_location}
     , next_location_ {0, 0}
     , food_ {init_food}
     , closest_visable_food_ {food_->closest_food(current_location_, max_visable_distace_)}

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1,7 +1,7 @@
 #include <cfloat>
 #include <math.h>
 
-//#include "evo_math.h"
+#include "evo_math.h"
 #include "creature.h"
 
 evo_sim::Creature::Creature(uint16_t init_id, float init_energy, Food* init_food)
@@ -18,12 +18,6 @@ void evo_sim::Creature::perform_day_actions() {
     energy_ -= 1.5; // TODO - make this a function of max_visable_distance_
     closest_visable_food_ = food_->closest_food(current_location_, max_visable_distace_);
     update_location();
-}
-
-float distance(evo_sim::point a, evo_sim::point b) {
-    uint32_t x = pow(a.first - b.first , 2);
-    uint32_t y = pow(a.second - b.second, 2);
-    return sqrt(x + y);
 }
 
 void evo_sim::Creature::update_location() {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1,55 +1,44 @@
 #include <cfloat>
 #include <math.h>
 
+//#include "evo_math.h"
 #include "creature.h"
 
-evo_sim::Creature::Creature(uint16_t init_id, float init_energy, std::vector<point> init_food)
+evo_sim::Creature::Creature(uint16_t init_id, float init_energy, Food* init_food)
     : id_ {init_id}
     , energy_ {init_energy}
+    , food_ {init_food}
     , current_location_ {0, 0}
     , next_location_ {0, 0}
-    , closest_visable_food_ {UINT16_MAX, UINT16_MAX}
     , last_food_eaten_ {std::nullopt}
-{
-    update_visable_food(init_food);
-}
+    , closest_visable_food_ {food_->closest_food(current_location_, max_visable_distace_)}
+{ }
 
-void evo_sim::Creature::perform_day_actions(std::vector<point> all_food) {    
+void evo_sim::Creature::perform_day_actions() {    
     energy_ -= 1.5; // TODO - make this a function of max_visable_distance_
-    
-    update_visable_food(all_food);
+    closest_visable_food_ = food_->closest_food(current_location_, max_visable_distace_);
     update_location();
 }
 
-void evo_sim::Creature::update_visable_food(std::vector<point> all_food) {
-    float distance_to_closest_food = FLT_MAX;
-
-    for (point food : all_food) {
-        // Filter food outside visable range
-        if (abs(food.first - current_location_.first) > max_visable_distace_) { continue; }
-        if (abs(food.second - current_location_.second) > max_visable_distace_) { continue; }
-
-        // Get distance to food
-        float distance_to_food = distance(food, current_location_);
-
-        // Track closest food
-        if (distance_to_food > distance_to_closest_food) { continue; }
-        distance_to_closest_food = distance_to_food;
-        closest_visable_food_ = food;
-    }
+float distance(evo_sim::point a, evo_sim::point b) {
+    uint32_t x = pow(a.first - b.first , 2);
+    uint32_t y = pow(a.second - b.second, 2);
+    return sqrt(x + y);
 }
 
 void evo_sim::Creature::update_location() {
     // Calculate next location
-    float distance_to_food = distance(current_location_, closest_visable_food_);
+    if (!closest_visable_food_.has_value()) { return; }
+
+    float distance_to_food = distance(current_location_, closest_visable_food_.value());
     if (distance_to_food > static_cast<float>(speed_)) {
-        uint16_t x_dif = closest_visable_food_.first - current_location_.first;
-        uint16_t y_dif = closest_visable_food_.second - current_location_.second;
+        uint16_t x_dif = closest_visable_food_->first - current_location_.first;
+        uint16_t y_dif = closest_visable_food_->second - current_location_.second;
         float distance_ratio = speed_ / distance_to_food;
         next_location_.first = current_location_.first + (x_dif * distance_ratio);
         next_location_.second = current_location_.second + (y_dif * distance_ratio);
     } else {
-        next_location_ = closest_visable_food_;
+        next_location_ = closest_visable_food_.value();
     }
 
     // Energy cost for moving
@@ -70,10 +59,4 @@ std::optional<evo_sim::point> evo_sim::Creature::last_food_eaten() {
     evo_sim::point food = last_food_eaten_.value();
     last_food_eaten_ = std::nullopt;
     return food;
-}
-
-float evo_sim::Creature::distance(point a, point b) {
-    uint32_t x = pow(a.first - b.first , 2);
-    uint32_t y = pow(a.second - b.second, 2);
-    return sqrt(x + y);
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -14,7 +14,7 @@ evo_sim::Creature::Creature(uint16_t init_id, float init_energy, Food* init_food
     , closest_visable_food_ {food_->closest_food(current_location_, max_visable_distace_)}
 { }
 
-void evo_sim::Creature::perform_day_actions() {    
+void evo_sim::Creature::perform_day_actions() {   
     energy_ -= 1.5; // TODO - make this a function of max_visable_distance_
     closest_visable_food_ = food_->closest_food(current_location_, max_visable_distace_);
     update_location();

--- a/src/evo_math.cpp
+++ b/src/evo_math.cpp
@@ -1,0 +1,7 @@
+#include "evo_math.h"
+
+float evo_sim::distance(point a, point b) {
+    uint32_t x = pow(a.first - b.first , 2);
+    uint32_t y = pow(a.second - b.second, 2);
+    return sqrt(x + y);
+}

--- a/src/evo_math.cpp
+++ b/src/evo_math.cpp
@@ -5,3 +5,7 @@ float evo_sim::distance(point a, point b) {
     uint32_t y = pow(a.second - b.second, 2);
     return sqrt(x + y);
 }
+
+uint32_t evo_sim::triangular_number(uint16_t n) {
+    return (n * (n + 1)) / 2;
+}

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -4,8 +4,6 @@
 #include "food.h"
 #include "logger.h"
 
-#include <iostream>
-
 evo_sim::Logger::Logger(World* world_ref)
     : count_ {0}
     , world_ {world_ref}
@@ -20,13 +18,12 @@ evo_sim::Logger::~Logger() {
 }
 
 void evo_sim::Logger::log_world_state() {
-    
     file_ << "Time increment " << count_++ << ":\n";
-    std::cout << "lws\n";
 
     for (int y=0; y<world_->height(); y++) {
         for (int x=0; x<world_->width(); x++) {
             log_point(x, y);
+            file_.flush();
         }
         file_ << "\n";
     }
@@ -41,7 +38,7 @@ void evo_sim::Logger::log_world_state() {
 }
 
 void evo_sim::Logger::log_point(uint16_t x, uint16_t y) {
-    for (Creature creature : world_->creatures()) {
+    for (Creature& creature : world_->creatures()) {
         if (creature.location().first != x) { continue; }
         if (creature.location().second != y) { continue; }
 
@@ -59,8 +56,8 @@ void evo_sim::Logger::log_point(uint16_t x, uint16_t y) {
         return;
     }
 
-    std::shared_ptr<Food> food { world_->food() };
-    if (food->is_food({x, y})) {
+    bool is_food = world_->food()->is_food({x, y});
+    if (is_food) {
         file_ << "f ";
         return;
     }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -4,11 +4,14 @@
 #include "food.h"
 #include "logger.h"
 
+#include <iostream>
+
 evo_sim::Logger::Logger(World* world_ref)
     : count_ {0}
     , world_ {world_ref}
     , file_ {file_name_}
 {
+    file_ << "test\n";
     if (!file_.is_open()) throw "could not open output file";
 }
 
@@ -17,7 +20,9 @@ evo_sim::Logger::~Logger() {
 }
 
 void evo_sim::Logger::log_world_state() {
+    
     file_ << "Time increment " << count_++ << ":\n";
+    std::cout << "lws\n";
 
     for (int y=0; y<world_->height(); y++) {
         for (int x=0; x<world_->width(); x++) {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,4 +1,7 @@
+#include <memory>
+
 #include "creature.h"
+#include "food.h"
 #include "logger.h"
 
 evo_sim::Logger::Logger(World* world_ref)
@@ -51,10 +54,8 @@ void evo_sim::Logger::log_point(uint16_t x, uint16_t y) {
         return;
     }
 
-    for (point food : world_->food_locations()) {
-        if (food.first != x) { continue; }
-        if (food.second != y) { continue; }
-
+    std::shared_ptr<Food> food { world_->food() };
+    if (food->is_food({x, y})) {
         file_ << "f ";
         return;
     }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -9,7 +9,6 @@ evo_sim::Logger::Logger(World* world_ref)
     , world_ {world_ref}
     , file_ {file_name_}
 {
-    file_ << "test\n";
     if (!file_.is_open()) throw "could not open output file";
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -22,7 +22,6 @@ void evo_sim::Logger::log_world_state() {
     for (int y=0; y<world_->height(); y++) {
         for (int x=0; x<world_->width(); x++) {
             log_point(x, y);
-            file_.flush();
         }
         file_ << "\n";
     }

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -13,11 +13,12 @@ void evo_sim::World::update_state() {
     // Creature actions
     for (Creature& creature : creatures_) {
         creature.perform_day_actions();
+    }
 
-        std::optional<point> eaten_food = creature.last_food_eaten();
-        if (eaten_food == std::nullopt) { continue; }
-
-        food_.remove_food(eaten_food.value());
+    // Update food
+    for (Creature& creature : creatures_) {
+        creature.update_energy();
+        food_.remove_eaten_food();
     }
 
     // Remove dead creatures

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -3,26 +3,21 @@
 
 #include "world.h"
 
-evo_sim::World::World() {
-    food_locations_.push_back({1, 1});
-    food_locations_.push_back({2, 2});
-    food_locations_.push_back({2, 5});
-    food_locations_.push_back({2, 12});
-    creatures_.push_back(Creature{0, 10.0, food_locations_});
+evo_sim::World::World()
+    : food_ {}
+{
+    creatures_.push_back(Creature{0, 10.0, &food_});
 }
 
 void evo_sim::World::update_state() {
     // Creature actions
     for (Creature& creature : creatures_) {
-        creature.perform_day_actions(food_locations_);
+        creature.perform_day_actions();
 
         std::optional<point> eaten_food = creature.last_food_eaten();
         if (eaten_food == std::nullopt) { continue; }
 
-        food_locations_.erase(
-            std::remove(food_locations_.begin(), food_locations_.end(), eaten_food),
-            food_locations_.end()
-        );
+        food_.remove_food(eaten_food.value());
     }
 
     // Remove dead creatures

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -6,7 +6,8 @@
 evo_sim::World::World()
     : food_ {}
 {
-    creatures_.push_back(Creature{0, 10.0, &food_});
+    creatures_.push_back(Creature{0, 10.0, &food_, {1, 1}});
+    creatures_.push_back(Creature{1, 10.0, &food_, {5, 1}});
 }
 
 void evo_sim::World::update_state() {


### PR DESCRIPTION
Make a dedicated food object.  The food object holds all the food in the world and arbitrates requests for food when multiple creatures try to eat the same food at once.  Currently, creatures that were created first are favored.  This should eventually be modified to favor the creature that reached the food first based on speed and previous location.